### PR TITLE
fix: update CI workflow to use pnpm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,16 +46,17 @@ jobs:
     name: Lint & Build
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          cache: npm
+          cache: pnpm
           node-version: lts/*
-      - run: npm clean-install --legacy-peer-deps
+      - run: pnpm install
         # Linting can be skipped
-      - run: npm run lint --if-present
+      - run: pnpm run lint --if-present
         if: github.event.inputs.test != 'false'
         # But not the build script, as semantic-release will crash if this command fails so it makes sense to test it early
-      - run: npm run prepublishOnly --if-present
+      - run: pnpm run prepublishOnly --if-present
 
   test:
     needs: build
@@ -86,12 +87,13 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          cache: npm
+          cache: pnpm
           node-version: ${{ matrix.node }}
-      - run: npm install --legacy-peer-deps
-      - run: npm test --if-present
+      - run: pnpm install
+      - run: pnpm test --if-present
 
   release:
     permissions:
@@ -110,12 +112,13 @@ jobs:
           # Need to fetch entire commit history to
           # analyze every commit since last release
           fetch-depth: 0
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          cache: npm
+          cache: pnpm
           node-version: lts/*
-      - run: npm clean-install --legacy-peer-deps
-      - run: npm audit signatures
+      - run: pnpm install
+      - run: pnpm audit signatures
         # Branches that will release new versions are defined in .releaserc.json
       - run: npx semantic-release
         # Don't allow interrupting the release step if the job is cancelled, as it can lead to an inconsistent state

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,10 +53,10 @@ jobs:
           node-version: lts/*
       - run: pnpm install
         # Linting can be skipped
-      - run: pnpm run lint --if-present
+      - run: pnpm run lint
         if: github.event.inputs.test != 'false'
         # But not the build script, as semantic-release will crash if this command fails so it makes sense to test it early
-      - run: pnpm run prepublishOnly --if-present
+      - run: pnpm run prepublishOnly
 
   test:
     needs: build
@@ -93,7 +93,7 @@ jobs:
           cache: pnpm
           node-version: ${{ matrix.node }}
       - run: pnpm install
-      - run: pnpm test --if-present
+      - run: pnpm test
 
   release:
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,10 +53,10 @@ jobs:
           node-version: lts/*
       - run: pnpm install
         # Linting can be skipped
-      - run: pnpm run lint
+      - run: pnpm run --if-present lint
         if: github.event.inputs.test != 'false'
         # But not the build script, as semantic-release will crash if this command fails so it makes sense to test it early
-      - run: pnpm run prepublishOnly
+      - run: pnpm run --if-present prepublishOnly
 
   test:
     needs: build
@@ -93,7 +93,8 @@ jobs:
           cache: pnpm
           node-version: ${{ matrix.node }}
       - run: pnpm install
-      - run: pnpm test
+      - name: Run tests
+        run: pnpm run --if-present test
 
   release:
     permissions:

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react": "^19",
     "sanity": "^5"
   },
+  "packageManager": "pnpm@10.26.1",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary
- Updates GitHub Actions workflow to use pnpm instead of npm
- Adds `pnpm/action-setup@v4` to all jobs
- Changes cache from `npm` to `pnpm`
- Replaces all npm commands with pnpm equivalents

Fixes the CI error: `Dependencies lock file is not found... Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock`